### PR TITLE
Fixed bug where class is passed in as rank and rank as class

### DIFF
--- a/TOSExpViewer/Service/ExperienceUtilityService.cs
+++ b/TOSExpViewer/Service/ExperienceUtilityService.cs
@@ -324,7 +324,7 @@ namespace TOSExpViewer.Service
         };
 
         // TODO: better way to determine the difference besides using an enumeration? base level doesn't need rank but class level does so it's kinda ugly/messy.
-        public static int GetRequiredExperienceForLevel(ExperienceType experienceType, int level, int rank)
+        public static int GetRequiredExperienceForLevel(ExperienceType experienceType, int rank, int level)
         {
             int requiredExperience = 0;
 


### PR DESCRIPTION
Made GetRequiredExperienceForLevel order rank/level arguments the same way as the rest of the methods in the class.

Fixes #13 